### PR TITLE
Fix mt5linux startup under Wine

### DIFF
--- a/Metatrader/start.sh
+++ b/Metatrader/start.sh
@@ -123,7 +123,7 @@ fi
 
 # Start the MT5 server on Linux
 show_message "[7/7] Starting the mt5linux server..."
-python3 -m mt5linux --host 0.0.0.0 -p $mt5server_port -w $wine_executable python.exe &
+$wine_executable python -m mt5linux --host 0.0.0.0 -p "$mt5server_port" &
 
 # Give the server some time to start
 sleep 5


### PR DESCRIPTION
## Summary
- Run the mt5linux server with the Wine Python environment that already has MetaTrader5 and mt5linux installed.
- Remove the obsolete Linux-side `-w` invocation that now fails with `Error: Unknown switch -w`.

## Context
This addresses the startup failure reported in #28. The current command exits before the server binds port 8001 because recent mt5linux/RPyC CLI handling no longer accepts `-w`. Running `python -m mt5linux` through Wine keeps the server in the same environment as the MetaTrader5 Python module and preserves the existing host/port binding.

## Validation
- `bash -n Metatrader/start.sh`