### PR TITLE
Run mt5linux server from Wine Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources \
     && dpkg --add-architecture i386 \
     && apt-get update \
-    && apt-get install --install-recommends -y winehq-stable \
+    && apt-get install --install-recommends -y winehq-staging \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apt/keyrings/winehq-archive.key
 

--- a/Metatrader/start.sh
+++ b/Metatrader/start.sh
@@ -11,6 +11,8 @@ MT5_CMD_OPTIONS="${MT5_CMD_OPTIONS:-}"
 mono_url="https://dl.winehq.org/wine/wine-mono/10.3.0/wine-mono-10.3.0-x86.msi"
 python_url="https://www.python.org/ftp/python/3.9.13/python-3.9.13.exe"
 mt5setup_url="https://download.mql5.com/cdn/web/metaquotes.software.corp/mt5/mt5setup.exe"
+mt5linux_package="${MT5LINUX_PACKAGE:-mt5linux>=0.1.9}"
+rpyc_package="${RPYC_PACKAGE:-}"
 
 # Function to display a graphical message
 show_message() {
@@ -96,10 +98,12 @@ show_message "[6/7] Installing MetaTrader5 library in Windows"
 if ! is_wine_python_package_installed "MetaTrader5==$metatrader_version"; then
     $wine_executable python -m pip install --no-cache-dir MetaTrader5==$metatrader_version
 fi
-# Install mt5linux library in Windows if not installed
-show_message "[6/7] Checking and installing mt5linux library in Windows if necessary"
-if ! is_wine_python_package_installed "mt5linux"; then
-    $wine_executable python -m pip install --no-cache-dir "mt5linux>=0.1.9"
+# Install mt5linux in the same Wine Python environment that runs the RPyC server.
+show_message "[6/7] Installing mt5linux library in Wine"
+if [ -n "$rpyc_package" ]; then
+    $wine_executable python -m pip install --upgrade --no-cache-dir "$mt5linux_package" "$rpyc_package"
+else
+    $wine_executable python -m pip install --upgrade --no-cache-dir "$mt5linux_package"
 fi
 
 # Install python-dateutil if needed (datetime is built-in, but dateutil adds features)
@@ -108,22 +112,15 @@ if ! is_wine_python_package_installed "python-dateutil"; then
     $wine_executable python -m pip install --no-cache-dir python-dateutil
 fi
 
-# Install mt5linux library in Linux if not installed
-show_message "[6/7] Checking and installing mt5linux library in Linux if necessary"
-if ! is_python_package_installed "mt5linux"; then
-    pip install --break-system-packages --no-cache-dir --no-deps mt5linux && \
-    pip install --break-system-packages --no-cache-dir rpyc plumbum numpy
-fi
-
 # Install pyxdg library in Linux if not installed
 show_message "[6/7] Checking and installing pyxdg library in Linux if necessary"
 if ! is_python_package_installed "pyxdg"; then
     pip install --break-system-packages --no-cache-dir pyxdg
 fi
 
-# Start the MT5 server on Linux
+# Start the mt5linux server in Wine so the server and MetaTrader5 module share one Python environment.
 show_message "[7/7] Starting the mt5linux server..."
-python3 -m mt5linux --host 0.0.0.0 -p $mt5server_port -w $wine_executable python.exe &
+$wine_executable python -m mt5linux --host 0.0.0.0 -p "$mt5server_port" &
 
 # Give the server some time to start
 sleep 5

--- a/Metatrader/start.sh
+++ b/Metatrader/start.sh
@@ -99,11 +99,15 @@ if ! is_wine_python_package_installed "MetaTrader5==$metatrader_version"; then
     $wine_executable python -m pip install --no-cache-dir MetaTrader5==$metatrader_version
 fi
 # Install mt5linux in the same Wine Python environment that runs the RPyC server.
-show_message "[6/7] Installing mt5linux library in Wine"
-if [ -n "$rpyc_package" ]; then
-    $wine_executable python -m pip install --upgrade --no-cache-dir "$mt5linux_package" "$rpyc_package"
-else
-    $wine_executable python -m pip install --upgrade --no-cache-dir "$mt5linux_package"
+show_message "[6/7] Checking mt5linux library in Wine"
+if [ -n "$RPYC_PACKAGE" ] || [ -n "$MT5LINUX_PACKAGE" ]; then
+    if [ -n "$rpyc_package" ]; then
+        $wine_executable python -m pip install --upgrade --no-cache-dir "$mt5linux_package" "$rpyc_package"
+    else
+        $wine_executable python -m pip install --upgrade --no-cache-dir "$mt5linux_package"
+    fi
+elif ! is_wine_python_package_installed "mt5linux"; then
+    $wine_executable python -m pip install --no-cache-dir "$mt5linux_package"
 fi
 
 # Install python-dateutil if needed (datetime is built-in, but dateutil adds features)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ True
 
 The port configuration can be adjusted as per the instructions in the KasmVNC repository.
 
+### mt5linux and RPyC packages
+
+The RPyC server runs in the Wine Python environment, next to the Windows `MetaTrader5` package. By default the container installs `mt5linux>=0.1.9` there. You can override the package specifier with `MT5LINUX_PACKAGE`, and you can optionally install a matching explicit RPyC package with `RPYC_PACKAGE`.
+
+This is useful when testing a patched mt5linux build before it is released:
+
+```yaml
+environment:
+  - "MT5LINUX_PACKAGE=mt5linux @ https://github.com/<owner>/mt5linux/archive/<commit>.zip"
+  - "RPYC_PACKAGE=rpyc>=6.0.0,<7"
+```
+
+Use the same RPyC major version on the remote Python client and in this container. RPyC 5.x clients and 6.x servers are not wire-compatible.
+
 ### MetaTrader 5 Command Line Options
 
 You can pass command line options to MetaTrader 5 using the `MT5_CMD_OPTIONS` environment variable. This is useful for custom configurations, tester modes, or other MetaTrader command line parameters.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The port configuration can be adjusted as per the instructions in the KasmVNC re
 
 ### mt5linux and RPyC packages
 
-The RPyC server runs in the Wine Python environment, next to the Windows `MetaTrader5` package. By default the container installs `mt5linux>=0.1.9` there. You can override the package specifier with `MT5LINUX_PACKAGE`, and you can optionally install a matching explicit RPyC package with `RPYC_PACKAGE`.
+The RPyC server runs in the Wine Python environment, next to the Windows `MetaTrader5` package. By default the container installs `mt5linux>=0.1.9` there only when `mt5linux` is missing, so normal restarts do not depend on PyPI availability or drift package versions. You can override the package specifier with `MT5LINUX_PACKAGE`, and you can optionally install a matching explicit RPyC package with `RPYC_PACKAGE`; setting either override forces an upgrade/install on startup.
 
 This is useful when testing a patched mt5linux build before it is released:
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The port configuration can be adjusted as per the instructions in the KasmVNC re
 
 ### mt5linux and RPyC packages
 
-The RPyC server runs in the Wine Python environment, next to the Windows `MetaTrader5` package. By default the container installs `mt5linux>=0.1.9` there only when `mt5linux` is missing, so normal restarts do not depend on PyPI availability or drift package versions. You can override the package specifier with `MT5LINUX_PACKAGE`, and you can optionally install a matching explicit RPyC package with `RPYC_PACKAGE`; setting either override forces an upgrade/install on startup.
+The RPyC server runs in the Wine Python environment, next to the Windows `MetaTrader5` package. By default the container installs `mt5linux>=0.1.9` there only when `mt5linux` is missing, so normal restarts do not depend on PyPI availability or drift package versions. The image also installs WineHQ staging by default because stable builds can trip MetaTrader's installer with `A debugger has been found running in your system...` on first boot. You can override the package specifier with `MT5LINUX_PACKAGE`, and you can optionally install a matching explicit RPyC package with `RPYC_PACKAGE`; setting either override forces an upgrade/install on startup.
 
 This is useful when testing a patched mt5linux build before it is released:
 
@@ -196,6 +196,8 @@ environment:
 ```
 
 Use the same RPyC major version on the remote Python client and in this container. RPyC 5.x clients and 6.x servers are not wire-compatible.
+
+If you are upgrading an existing `/config` volume from an older stable-Wine image and MT5 installation previously failed, start once with a clean Wine prefix (remove `/config/.wine` or use a fresh `/config` volume) so MetaTrader can reinstall under staging.
 
 ### MetaTrader 5 Command Line Options
 


### PR DESCRIPTION
## Summary
- run the `mt5linux` RPyC server from Wine Python, where the Windows `MetaTrader5` package is installed
- remove the native Linux-side `mt5linux`/RPyC install path that can create client/server version skew
- add `MT5LINUX_PACKAGE` and `RPYC_PACKAGE` overrides so deployments can test a patched `mt5linux` build or align explicit RPyC versions

## Why
Running one side of the mt5linux/RPyC stack in native Linux Python and the other in Wine Python can lead to incompatible RPyC versions. RPyC 5.x and 6.x are not wire-compatible, and a mismatch can fail at runtime with errors such as `ValueError: invalid message type: 18`.

This also makes it possible to validate the pending mt5linux RPyC 6 compatibility work before a PyPI release by passing package specifiers through environment variables.

Related mt5linux PR: https://github.com/lucas-campagna/mt5linux/pull/33

## Validation
- `bash -n Metatrader/start.sh`

I did not run a full Docker/MetaTrader smoke test in this environment.